### PR TITLE
MongodbPartitioner using wrong splitKey

### DIFF
--- a/spark-mongodb/src/main/scala/com/stratio/provider/mongodb/partitioner/MongodbPartitioner.scala
+++ b/spark-mongodb/src/main/scala/com/stratio/provider/mongodb/partitioner/MongodbPartitioner.scala
@@ -138,7 +138,7 @@ class MongodbPartitioner(
 
     val cmd: MongoDBObject = MongoDBObject(
       "splitVector" -> collectionFullName,
-      "keyPattern" -> MongoDBObject(MongodbConfig.SplitKey -> 1),
+      "keyPattern" -> MongoDBObject(config[String](MongodbConfig.SplitKey) -> 1),
       "force" -> false,
       "maxChunkSize" -> config(MongodbConfig.SplitSize)
     )


### PR DESCRIPTION
splitVector command was using literal 'splitKey' instead of value of config paramater MongodbConfig.SplitKey

The error was being swallowed up by the .recover