### PR TITLE
Add basic examples

### DIFF
--- a/spark-mongodb-examples/pom.xml
+++ b/spark-mongodb-examples/pom.xml
@@ -39,14 +39,21 @@
     </licenses>
 
     <properties>
+        <scala.binary.version>2.10</scala.binary.version>
         <mongodb.provider.version>0.9.0-SNAPSHOT</mongodb.provider.version>
+        <spark.version>1.4.0</spark.version>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>com.stratio</groupId>
-            <artifactId>spark-mongodb-core</artifactId>
+            <artifactId>spark-mongodb-core_${scala.binary.version}</artifactId>
             <version>${mongodb.provider.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-sql_${scala.binary.version}</artifactId>
+            <version>${spark.version}</version>
         </dependency>
     </dependencies>
 

--- a/spark-mongodb-examples/pom.xml
+++ b/spark-mongodb-examples/pom.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to STRATIO (C) under one or more contributor license agreements.
+  ~ See the NOTICE file distributed with this work for additional information
+  ~ regarding copyright ownership.  The STRATIO (C) licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>com.stratio</groupId>
+        <artifactId>parent</artifactId>
+        <version>0.4.0</version>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>spark-mongodb-examples</artifactId>
+    <name>spark-mongodb examples</name>
+    <description>MongoDB examples</description>
+    <url>http://github.com/Stratio/spark-mongodb</url>
+    <packaging>jar</packaging>
+
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+        </license>
+    </licenses>
+
+    <properties>
+        <mongodb.provider.version>0.9.0-SNAPSHOT</mongodb.provider.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.stratio</groupId>
+            <artifactId>spark-mongodb-core</artifactId>
+            <version>${mongodb.provider.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <sourceDirectory>src/main/scala</sourceDirectory>
+        <plugins>
+            <plugin>
+                <groupId>org.scala-tools</groupId>
+                <artifactId>maven-scala-plugin</artifactId>
+                <version>2.15.2</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.3</version>
+                <configuration>
+                    <skip>true</skip>
+                    <source>1.7</source>
+                    <target>1.7</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>net.alchim31.maven</groupId>
+                <artifactId>scala-maven-plugin</artifactId>
+                <version>3.2.0</version>
+                <configuration>
+                    <checkMultipleScalaVersions>false</checkMultipleScalaVersions>
+                    <args>
+                        <arg>-Xmax-classfile-name</arg>
+                        <arg>130</arg>
+                    </args>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>compile</id>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <phase>compile</phase>
+                    </execution>
+                    <execution>
+                        <id>test-compile</id>
+                        <goals>
+                            <goal>testCompile</goal>
+                        </goals>
+                        <phase>test-compile</phase>
+                    </execution>
+                    <execution>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>
+
+

--- a/spark-mongodb-examples/src/main/scala/com/stratio/provider/mongodb/examples/DataFrameAPIExample.scala
+++ b/spark-mongodb-examples/src/main/scala/com/stratio/provider/mongodb/examples/DataFrameAPIExample.scala
@@ -1,0 +1,48 @@
+/*
+ *  Licensed to STRATIO (C) under one or more contributor license agreements.
+ *  See the NOTICE file distributed with this work for additional information
+ *  regarding copyright ownership. The STRATIO (C) licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License. You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied. See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package com.stratio.provider.mongodb.examples
+
+import com.stratio.provider.mongodb.examples.MongoExampleFunctions._
+
+object DataFrameAPIExample extends App with MongoDefaultConstants {
+
+  val mongoClient = prepareEnvironment()
+
+  withSQLContext { sqlContext =>
+
+    sqlContext.sql(
+      s"""|CREATE TEMPORARY TABLE $Collection
+          |(id STRING, age INT, description STRING, enrolled BOOLEAN, name STRING, optionalField BOOLEAN)
+          |USING $MongoProvider
+          |OPTIONS (
+          |host '$MongoHost:$MongoPort',
+          |database '$Database',
+          |collection '$Collection'
+          |)
+       """.stripMargin.replaceAll("\n", " "))
+
+    import org.apache.spark.sql.functions._
+
+    val studentsDF = sqlContext.read.format(MongoProvider).table(Collection)
+    studentsDF.where(studentsDF("age") > 15).groupBy(studentsDF("enrolled")).agg(avg("age"), max("age")).show(5)
+
+  }
+
+  cleanEnvironment(mongoClient)
+}

--- a/spark-mongodb-examples/src/main/scala/com/stratio/provider/mongodb/examples/ExampleUtils.scala
+++ b/spark-mongodb-examples/src/main/scala/com/stratio/provider/mongodb/examples/ExampleUtils.scala
@@ -1,0 +1,85 @@
+/*
+ *  Licensed to STRATIO (C) under one or more contributor license agreements.
+ *  See the NOTICE file distributed with this work for additional information
+ *  regarding copyright ownership. The STRATIO (C) licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License. You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied. See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package com.stratio.provider.mongodb.examples
+
+import com.mongodb.QueryBuilder
+import com.mongodb.casbah.MongoClient
+import com.mongodb.casbah.commons.MongoDBObject
+import com.stratio.provider.mongodb.examples.DataFrameAPIExample._
+import org.apache.spark.{SparkContext, SparkConf}
+import org.apache.spark.sql.SQLContext
+
+trait MongoDefaultConstants {
+  val Database = "highschool"
+  val Collection = "students"
+  val MongoHost = "127.0.0.1"
+  val MongoPort = 27017
+  val MongoProvider = "com.stratio.provider.mongodb"
+}
+
+object MongoExampleFunctions {
+
+  def withSQLContext(block: SQLContext => Unit) = {
+
+    val sparkConf = new SparkConf().
+      setAppName("MongoDFExample").
+      setMaster("local[4]")
+
+    val sc = new SparkContext(sparkConf)
+    try {
+      val sqlContext = new SQLContext(sc)
+      block(sqlContext)
+    } finally {
+      sc.stop()
+    }
+
+  }
+
+  def prepareEnvironment(): MongoClient = {
+    val mongoClient = MongoClient(MongoHost,MongoPort)
+    populateTable(mongoClient)
+    mongoClient
+  }
+
+  def cleanEnvironment(mongoClient: MongoClient) = {
+    cleanData(mongoClient)
+    mongoClient.close()
+  }
+
+  private def populateTable(client: MongoClient): Unit = {
+
+    val collection = client(Database)(Collection)
+    for (a <- 1 to 10) {
+      collection.insert{
+        MongoDBObject("id" -> a.toString,
+          "age" -> (10+a),
+          "description" -> s"description $a",
+          "enrolled" -> (a % 2 == 0 ),
+          "name" -> s"Name $a"
+        )
+      }
+    }
+    collection.update(QueryBuilder.start("age").greaterThan(14).get, MongoDBObject( ("$set", MongoDBObject( ("optionalField", true))) ), multi=true)
+  }
+
+  private def cleanData(client: MongoClient): Unit = {
+    val collection = client(Database)(Collection)
+    collection.dropCollection()
+  }
+}

--- a/spark-mongodb-examples/src/main/scala/com/stratio/provider/mongodb/examples/ExampleUtils.scala
+++ b/spark-mongodb-examples/src/main/scala/com/stratio/provider/mongodb/examples/ExampleUtils.scala
@@ -20,10 +20,10 @@ package com.stratio.provider.mongodb.examples
 
 import com.mongodb.QueryBuilder
 import com.mongodb.casbah.MongoClient
-import com.mongodb.casbah.commons.MongoDBObject
+import com.mongodb.casbah.commons.{MongoDBList, MongoDBObject}
 import com.stratio.provider.mongodb.examples.DataFrameAPIExample._
-import org.apache.spark.{SparkContext, SparkConf}
 import org.apache.spark.sql.SQLContext
+import org.apache.spark.{SparkConf, SparkContext}
 
 trait MongoDefaultConstants {
   val Database = "highschool"
@@ -52,7 +52,7 @@ object MongoExampleFunctions {
   }
 
   def prepareEnvironment(): MongoClient = {
-    val mongoClient = MongoClient(MongoHost,MongoPort)
+    val mongoClient = MongoClient(MongoHost, MongoPort)
     populateTable(mongoClient)
     mongoClient
   }
@@ -66,16 +66,18 @@ object MongoExampleFunctions {
 
     val collection = client(Database)(Collection)
     for (a <- 1 to 10) {
-      collection.insert{
+      collection.insert {
         MongoDBObject("id" -> a.toString,
-          "age" -> (10+a),
+          "age" -> (10 + a),
           "description" -> s"description $a",
-          "enrolled" -> (a % 2 == 0 ),
+          "enrolled" -> (a % 2 == 0),
           "name" -> s"Name $a"
         )
       }
     }
-    collection.update(QueryBuilder.start("age").greaterThan(14).get, MongoDBObject( ("$set", MongoDBObject( ("optionalField", true))) ), multi=true)
+
+    collection.update(QueryBuilder.start("age").greaterThan(14).get, MongoDBObject(("$set", MongoDBObject(("optionalField", true)))), multi = true)
+    collection.update(QueryBuilder.start("age").is(14).get, MongoDBObject(("$set", MongoDBObject(("fieldWithSubDoc", MongoDBObject(("subDoc", MongoDBList("foo", "bar"))))))))
   }
 
   private def cleanData(client: MongoClient): Unit = {

--- a/spark-mongodb-examples/src/main/scala/com/stratio/provider/mongodb/examples/NestedFieldsExample.scala
+++ b/spark-mongodb-examples/src/main/scala/com/stratio/provider/mongodb/examples/NestedFieldsExample.scala
@@ -1,0 +1,43 @@
+/*
+ *  Licensed to STRATIO (C) under one or more contributor license agreements.
+ *  See the NOTICE file distributed with this work for additional information
+ *  regarding copyright ownership. The STRATIO (C) licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License. You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied. See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package com.stratio.provider.mongodb.examples
+
+import com.stratio.provider.mongodb.examples.MongoExampleFunctions._
+
+object NestedFieldsExample extends App with MongoDefaultConstants {
+
+  val mongoClient = prepareEnvironment()
+
+  withSQLContext { sqlContext =>
+    sqlContext.sql(
+      s"""|CREATE TEMPORARY TABLE $Collection
+          |(id STRING, age INT, description STRING, enrolled BOOLEAN, name STRING, optionalField BOOLEAN, fieldWithSubDoc struct<subDoc: array<STRING>> )
+          |USING $MongoProvider
+          |OPTIONS (
+          |host '$MongoHost:$MongoPort',
+          |database '$Database',
+          |collection '$Collection'
+          |)
+       """.stripMargin.replaceAll("\n", " "))
+
+    sqlContext.sql(s"SELECT fieldWithSubDoc.subDoc[0] FROM $Collection WHERE age = 14").show(5)
+  }
+
+  cleanEnvironment(mongoClient)
+}

--- a/spark-mongodb-examples/src/main/scala/com/stratio/provider/mongodb/examples/SQLExample.scala
+++ b/spark-mongodb-examples/src/main/scala/com/stratio/provider/mongodb/examples/SQLExample.scala
@@ -1,0 +1,45 @@
+/*
+ *  Licensed to STRATIO (C) under one or more contributor license agreements.
+ *  See the NOTICE file distributed with this work for additional information
+ *  regarding copyright ownership. The STRATIO (C) licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License. You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied. See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package com.stratio.provider.mongodb.examples
+
+import com.stratio.provider.mongodb.examples.MongoExampleFunctions._
+
+object SQLExample extends App with MongoDefaultConstants {
+
+  val mongoClient = prepareEnvironment()
+
+  withSQLContext { sqlContext =>
+
+    sqlContext.sql(
+      s"""|CREATE TEMPORARY TABLE $Collection
+          |(id STRING, age INT, description STRING, enrolled BOOLEAN, name STRING, optionalField BOOLEAN)
+          |USING $MongoProvider
+          |OPTIONS (
+          |host '$MongoHost:$MongoPort',
+          |database '$Database',
+          |collection '$Collection'
+          |)
+       """.stripMargin.replaceAll("\n", " "))
+
+    sqlContext.sql(s"SELECT id, name FROM $Collection WHERE age > 16").show(5)
+
+  }
+
+  cleanEnvironment(mongoClient)
+}


### PR DESCRIPTION
The examples show how to create a basic application using MongoDB and Spark. Although they are in the same repo, examples are out of the project. If you are using IntellIJ it should be opened as an isolated project. This PR includes:
- SQL example
- DataFrameAPI example