### PR TITLE
Use generic RDD[DBObject] for MongodbSchema

### DIFF
--- a/spark-mongodb/src/main/scala/com/stratio/datasource/mongodb/schema/MongodbSchema.scala
+++ b/spark-mongodb/src/main/scala/com/stratio/datasource/mongodb/schema/MongodbSchema.scala
@@ -16,8 +16,8 @@
 package com.stratio.datasource.mongodb.schema
 
 import com.mongodb.casbah.Imports._
-import com.stratio.datasource.mongodb.rdd.MongodbRDD
 import com.stratio.datasource.schema.SchemaProvider
+import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.ScalaReflection
 import org.apache.spark.sql.catalyst.analysis.HiveTypeCoercion
 import org.apache.spark.sql.types._
@@ -28,8 +28,8 @@ import org.apache.spark.sql.types._
  * @param samplingRatio Sampling ratio used to scan the RDD and extract
  *                      used fields.
  */
-case class MongodbSchema(
-  rdd: MongodbRDD,
+case class MongodbSchema[T <: RDD[DBObject]](
+  rdd: T,
   samplingRatio: Double) extends SchemaProvider with Serializable {
 
   override def schema(): StructType = {


### PR DESCRIPTION
This is backward compatible, but allows inferring the schema from an
existing RDD[DBObject].

The advantage is that it allows code like:
```
def createDataframe(sqlContext: SQLContext, rdd: RDD[DBObject], samplingRatio: Double = 1.0): DataFrame = {
    Try {
      val schema = MongodbSchema(rdd, samplingRatio).schema()
      val rowRDD = MongodbRowConverter.asRow(schema, rdd)
      sqlContext.createDataFrame(rowRDD, schema)
    } getOrElse sqlContext.emptyDataFrame
  }
```

Among the ways this is useful is that it allows interaction with the mongodb-hadoop-connector, which supports some features not yet implemented in spark-mongodb (like Split pattern min/max)