### PR TITLE
Fix doc parent

### DIFF
--- a/doc/pom.xml
+++ b/doc/pom.xml
@@ -24,9 +24,9 @@
     <name>Stratio Spark-MongoDB documentation</name>
     <packaging>pom</packaging>
     <parent>
-        <groupId>com.stratio</groupId>
-        <artifactId>spark-mongodb</artifactId>
-        <version>0.9.0-SNAPSHOT</version>
+    	<groupId>com.stratio.datasource</groupId>
+        <artifactId>spark-mongodb-parent</artifactId>
+	<version>0.10.0-SNAPSHOT</version>
     </parent>
     <properties>
         <jacoco.skip>true</jacoco.skip>


### PR DESCRIPTION
``` mvn clean ``` command was failing due to the parent of doc being not
found.