### PR TITLE
[CROSSDATA-196] [Mongo Datasource] Modification in the MongodbRowConverter Use Seq instead of ArrayBuffer

### DIFF
--- a/spark-mongodb/src/main/scala/com/stratio/datasource/mongodb/schema/MongodbRowConverter.scala
+++ b/spark-mongodb/src/main/scala/com/stratio/datasource/mongodb/schema/MongodbRowConverter.scala
@@ -97,7 +97,7 @@ with Serializable {
   def toDBObject(value: Any, dataType: DataType): Any = {
     Option(value).map{v =>
       (dataType,v) match {
-        case (ArrayType(elementType, _),array: ArrayBuffer[Any@unchecked]) =>
+        case (ArrayType(elementType, _),array: Seq[Any@unchecked]) =>
           val list: List[Any] = array.map{
             case obj => toDBObject(obj,elementType)
           }.toList

--- a/spark-mongodb/src/test/scala/com/stratio/datasource/mongodb/schema/MongodbRowConverterIT.scala
+++ b/spark-mongodb/src/test/scala/com/stratio/datasource/mongodb/schema/MongodbRowConverterIT.scala
@@ -30,6 +30,7 @@ import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 import org.scalatest.{FlatSpec, Matchers}
 
+import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 
 @RunWith(classOf[JUnitRunner])
@@ -80,7 +81,15 @@ with MongodbTestConstants {
       new StructField("att8", new StructType(
       Array(StructField("att81", IntegerType, false), StructField("att82",
         new ArrayType(StructType(Array(StructField("att821", IntegerType, false),StructField("att822", StringType, false))), false)
-        ,false))), false)
+        ,false))), false),
+    //  Subdocument with List of a document with wrapped array
+    new GenericRow(List(1, new mutable.WrappedArray.ofRef[AnyRef](Array(
+        new GenericRow(List(2,"b").toArray)
+      ))).toArray) ->
+      new StructField("att9", new StructType(
+        Array(StructField("att91", IntegerType, false), StructField("att92",
+          new ArrayType(StructType(Array(StructField("att921", IntegerType, false),StructField("att922", StringType, false))), false)
+          ,false))), false)
   )
 
   val rowSchema = new StructType(valueWithType.map(_._2).toArray)
@@ -95,7 +104,8 @@ with MongodbTestConstants {
           "att2" : 2.0 ,
           "att1" : 1,
           "att7" : {"att71": 1, "att72":{"att721":1, "att722":"b"}},
-          "att8" : {"att81": 1, "att82":[{"att821":2, "att822":"b"}]}
+          "att8" : {"att81": 1, "att82":[{"att821":2, "att822":"b"}]},
+          "att9" : {"att91": 1, "att92":[{"att921":2, "att922":"b"}]}
           }
           """).asInstanceOf[DBObject]
 


### PR DESCRIPTION
… as values's type  of ArrayType field.

This modification is necessary because if I read a complex data structure from a json file and I try to write it into mongodb I receive an exception;

org.apache.spark.SparkException: Job aborted due to stage failure: Task 1 in stage 10.0 failed 1 times, most recent failure: Lost task 1.0 in stage 10.0 (TID 15, localhost): org.bson.codecs.configuration.CodecConfigurationException: Can't find a codec for class org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema.
	at org.bson.codecs.configuration.CodecCache.getOrThrow(CodecCache.java:46)
	at org.bson.codecs.configuration.ProvidersCodecRegistry.get(ProvidersCodecRegistry.java:63)
	at org.bson.codecs.configuration.ProvidersCodecRegistry.get(ProvidersCodecRegistry.java:37)
	at com.mongodb.DBObjectCodec.writeValue(DBObjectCodec.java:210)
	at com.mongodb.DBObjectCodec.encodeIterable(DBObjectCodec.java:269)
	at com.mongodb.DBObjectCodec.writeValue(DBObjectCodec.java:198)
	at com.mongodb.DBObjectCodec.encode(DBObjectCodec.java:128)
	at com.mongodb.DBObjectCodec.encode(DBObjectCodec.java:61)
	at com.mongodb.CompoundDBObjectCodec.encode(CompoundDBObjectCodec.java:48)
	at com.mongodb.CompoundDBObjectCodec.encode(CompoundDBObjectCodec.java:27)
	at org.bson.codecs.BsonDocumentWrapperCodec.encode(BsonDocumentWrapperCodec.java:63)
	at org.bson.codecs.BsonDocumentWrapperCodec.encode(BsonDocumentWrapperCodec.java:29)
	at com.mongodb.connection.InsertCommandMessage.writeTheWrites(InsertCommandMessage.java:99)
	at com.mongodb.connection.InsertCommandMessage.writeTheWrites(InsertCommandMessage.java:43)
	at com.mongodb.connection.BaseWriteCommandMessage.encodeMessageBody(BaseWriteCommandMessage.java:112)
	at com.mongodb.connection.BaseWriteCommandMessage.encodeMessageBody(BaseWriteCommandMessage.java:35)
	at com.mongodb.connection.RequestMessage.encode(RequestMessage.java:132)
	at com.mongodb.connection.BaseWriteCommandMessage.encode(BaseWriteCommandMessage.java:89)
	at com.mongodb.connection.WriteCommandProtocol.sendMessage(WriteCommandProtocol.java:170)
	at com.mongodb.connection.WriteCommandProtocol.execute(WriteCommandProtocol.java:73)
	at com.mongodb.connection.InsertCommandProtocol.execute(InsertCommandProtocol.java:66)
	at com.mongodb.connection.InsertCommandProtocol.execute(InsertCommandProtocol.java:37)
	at com.mongodb.connection.DefaultServer$DefaultServerProtocolExecutor.execute(DefaultServer.java:155)
	at com.mongodb.connection.DefaultServerConnection.executeProtocol(DefaultServerConnection.java:219)
	at com.mongodb.connection.DefaultServerConnection.insertCommand(DefaultServerConnection.java:108)
	at com.mongodb.operation.MixedBulkWriteOperation$Run$2.executeWriteCommandProtocol(MixedBulkWriteOperation.java:416)
	at com.mongodb.operation.MixedBulkWriteOperation$Run$RunExecutor.execute(MixedBulkWriteOperation.java:604)
	at com.mongodb.operation.MixedBulkWriteOperation$Run.execute(MixedBulkWriteOperation.java:363)
	at com.mongodb.operation.MixedBulkWriteOperation$1.call(MixedBulkWriteOperation.java:148)
	at com.mongodb.operation.MixedBulkWriteOperation$1.call(MixedBulkWriteOperation.java:141)
	at com.mongodb.operation.OperationHelper.withConnectionSource(OperationHelper.java:186)
	at com.mongodb.operation.OperationHelper.withConnection(OperationHelper.java:177)
	at com.mongodb.operation.MixedBulkWriteOperation.execute(MixedBulkWriteOperation.java:141)
	at com.mongodb.operation.MixedBulkWriteOperation.execute(MixedBulkWriteOperation.java:72)
	at com.mongodb.Mongo.execute(Mongo.java:747)
	at com.mongodb.Mongo$2.execute(Mongo.java:730)
	at com.mongodb.DBCollection.executeBulkWriteOperation(DBCollection.java:1968)
	at com.mongodb.BulkWriteOperation.execute(BulkWriteOperation.java:113)
	at com.mongodb.casbah.BulkWriteOperation$$anonfun$2.apply(BulkWriteOperation.scala:91)
	at com.mongodb.casbah.BulkWriteOperation$$anonfun$2.apply(BulkWriteOperation.scala:91)
	at scala.util.Try$.apply(Try.scala:161)
	at com.mongodb.casbah.BulkWriteOperation.execute(BulkWriteOperation.scala:91)
	at com.stratio.datasource.mongodb.writer.MongodbBatchWriter$$anonfun$save$1.apply(MongodbBatchWriter.scala:44)
	at com.stratio.datasource.mongodb.writer.MongodbBatchWriter$$anonfun$save$1.apply(MongodbBatchWriter.scala:37)
	at scala.collection.Iterator$class.foreach(Iterator.scala:727)
	at scala.collection.AbstractIterator.foreach(Iterator.scala:1157)
	at com.stratio.datasource.mongodb.writer.MongodbBatchWriter.save(MongodbBatchWriter.scala:37)

I do not know how to run the Integration tests so I have renamed the file MongodbRowConverterIT in MongodbRowConverterTest and renamed back after test runs