### PR TITLE
Provide `GenericRowWithSchema`s instead of `GeneticRow`s

### DIFF
--- a/spark-mongodb/src/main/scala/com/stratio/datasource/mongodb/schema/MongodbRowConverter.scala
+++ b/spark-mongodb/src/main/scala/com/stratio/datasource/mongodb/schema/MongodbRowConverter.scala
@@ -19,7 +19,7 @@ import com.mongodb.casbah.Imports._
 import com.stratio.datasource.schema.RowConverter
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.Row
-import org.apache.spark.sql.catalyst.expressions.GenericRow
+import org.apache.spark.sql.catalyst.expressions.{GenericRow, GenericRowWithSchema}
 import org.apache.spark.sql.types.{ArrayType, DataType, StructField, StructType}
 
 import scala.collection.mutable.ArrayBuffer
@@ -70,7 +70,7 @@ object MongodbRowConverter extends RowConverter[DBObject]
         json.get(name).flatMap(v => Option(v)).map(
           toSQL(_, dataType)).orNull
     }
-    Row.fromSeq(values)
+    new GenericRowWithSchema(values.toArray, schema)
   }
 
   /**


### PR DESCRIPTION
Changed the way the returned rows are built to make them include the schema.
This should enable new functionalities at Spark side.