### PR TITLE
Doc : Python Api fix

### DIFF
--- a/doc/src/site/sphinx/First_Steps.rst
+++ b/doc/src/site/sphinx/First_Steps.rst
@@ -229,7 +229,7 @@ Then:
 
 ::
 
- from pyspark.sql import SQLContext
+ from pyspark.sql import sqlContext
  sqlContext.sql("CREATE TEMPORARY TABLE students_table USING com.stratio.datasource.mongodb OPTIONS (host 'host:port', database 'highschool', collection 'students')")
  sqlContext.sql("SELECT * FROM students_table").collect()
 


### PR DESCRIPTION
sqlContext Is wrongly referenced on the documentation.
Reference : (https://spark.apache.org/docs/latest/api/python/pyspark.sql.html#pyspark.sql.SQLContext)