### PR TITLE
Support for null-safe equality comparison fillter

### DIFF
--- a/spark-mongodb/src/main/scala/com/stratio/datasource/mongodb/reader/MongodbReader.scala
+++ b/spark-mongodb/src/main/scala/com/stratio/datasource/mongodb/reader/MongodbReader.scala
@@ -107,6 +107,8 @@ class MongodbReader(
       sFilters.foreach {
         case EqualTo(attribute, value) =>
           queryBuilder.put(attribute).is(value)
+        case EqualNullSafe(attribute, value) =>
+          queryBuilder.put(attribute).is(value)
         case GreaterThan(attribute, value) =>
           queryBuilder.put(attribute).greaterThan(value)
         case GreaterThanOrEqual(attribute, value) =>


### PR DESCRIPTION
Simply I added a missing filter which is added for Spark 1.5

Spark does not pass EqualNullSafe filter having null value but instead IsNull. So it is safe to process identically with EqualTo.

However, it is not include test code because original test code is not include all fillter test so i did not include test code.