### PR TITLE
Fix `pruneSchema` (with index random access information) access modificator

### DIFF
--- a/spark-mongodb/src/main/scala/com/stratio/datasource/mongodb/MongodbRelation.scala
+++ b/spark-mongodb/src/main/scala/com/stratio/datasource/mongodb/MongodbRelation.scala
@@ -133,9 +133,10 @@ object MongodbRelation {
     * @param requiredColumnsWithIndex Required fields in statement including index within field for random accesses.
     * @return A new pruned schema
     */
-  private[this] def pruneSchema(
-                                          schema: StructType,
-                                          requiredColumnsWithIndex: Array[(String, Option[Int])]): StructType = {
+  def pruneSchema(
+                  schema: StructType,
+                  requiredColumnsWithIndex: Array[(String, Option[Int])]): StructType = {
+		  
     val name2sfield: Map[String, StructField] = schema.fields.map(f => f.name -> f).toMap
     StructType(
       requiredColumnsWithIndex.flatMap {

--- a/spark-mongodb/src/test/scala/com/stratio/datasource/mongodb/MongodbRelationIT.scala
+++ b/spark-mongodb/src/test/scala/com/stratio/datasource/mongodb/MongodbRelationIT.scala
@@ -85,7 +85,7 @@ with MongodbTestConstants{
 
   it should "prune schema to adapt it to required columns" + scalaBinaryVersion in {
 
-    MongodbRelation.pruneSchema(schema,Array()) should equal(
+    MongodbRelation.pruneSchema(schema,Array[String]()) should equal(
       new StructType(Array()))
 
     MongodbRelation.pruneSchema(schema,Array("fakeAtt")) should equal(


### PR DESCRIPTION
It should be public so it can be used from client-side code