### PR TITLE
Near and rawfilters

### DIFF
--- a/spark-mongodb/src/main/scala/com/stratio/datasource/mongodb/MongodbRelation.scala
+++ b/spark-mongodb/src/main/scala/com/stratio/datasource/mongodb/MongodbRelation.scala
@@ -43,7 +43,7 @@ class MongodbRelation(private val config: Config,
                        @transient val sqlContext: SQLContext) extends BaseRelation
 with PrunedFilteredScan with InsertableRelation {
 
-  implicit val c: Config = config
+  implicit val _: Config = config
 
   import MongodbRelation._
 

--- a/spark-mongodb/src/main/scala/com/stratio/datasource/mongodb/MongodbRelation.scala
+++ b/spark-mongodb/src/main/scala/com/stratio/datasource/mongodb/MongodbRelation.scala
@@ -43,6 +43,8 @@ class MongodbRelation(private val config: Config,
                        @transient val sqlContext: SQLContext) extends BaseRelation
 with PrunedFilteredScan with InsertableRelation {
 
+  implicit val c: Config = config
+
   import MongodbRelation._
 
   private val rddPartitioner: MongodbPartitioner =

--- a/spark-mongodb/src/main/scala/com/stratio/datasource/mongodb/query/FilterSection.scala
+++ b/spark-mongodb/src/main/scala/com/stratio/datasource/mongodb/query/FilterSection.scala
@@ -1,0 +1,111 @@
+/**
+ * Copyright (C) 2015 Stratio (http://stratio.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.stratio.datasource.mongodb.query
+
+import java.util.regex.Pattern
+
+import com.mongodb.QueryBuilder
+import com.mongodb.casbah.Imports
+import com.mongodb.casbah.Imports._
+import org.apache.spark.sql.sources._
+import com.stratio.datasource.util.Config
+import com.stratio.datasource.mongodb.config.MongodbConfig
+
+object FilterSection {
+
+  implicit def srcFilArr2filSel(sFilters: Array[Filter])(implicit config: Config): FilterSection =
+    new SourceFilters(sFilters)
+
+  def apply(sFilters: Array[Filter])(implicit config: Config): FilterSection =
+    srcFilArr2filSel(sFilters)
+
+  def apply(): FilterSection = NoFilters
+}
+
+trait FilterSection {
+  def filtersToDBObject(): DBObject
+}
+
+object NoFilters extends FilterSection {
+  override def filtersToDBObject(): Imports.DBObject = QueryBuilder.start.get()
+}
+
+class SourceFilters(
+                     sFilters: Array[Filter],
+                     parentFilterIsNot: Boolean = false
+                   )(implicit config: Config) extends FilterSection {
+
+  override def filtersToDBObject: DBObject = {
+    val queryBuilder: QueryBuilder = QueryBuilder.start
+
+    if (parentFilterIsNot) queryBuilder.not()
+
+    sFilters.foreach {
+      case EqualTo(attribute, value) =>
+        queryBuilder.put(attribute).is(checkObjectID(attribute, value))
+      case GreaterThan(attribute, value) =>
+        queryBuilder.put(attribute).greaterThan(checkObjectID(attribute, value))
+      case GreaterThanOrEqual(attribute, value) =>
+        queryBuilder.put(attribute).greaterThanEquals(checkObjectID(attribute, value))
+      case In(attribute, values) =>
+        queryBuilder.put(attribute).in(values.map(value => checkObjectID(attribute, value)))
+      case LessThan(attribute, value) =>
+        queryBuilder.put(attribute).lessThan(checkObjectID(attribute, value))
+      case LessThanOrEqual(attribute, value) =>
+        queryBuilder.put(attribute).lessThanEquals(checkObjectID(attribute, value))
+      case IsNull(attribute) =>
+        queryBuilder.put(attribute).is(null)
+      case IsNotNull(attribute) =>
+        queryBuilder.put(attribute).notEquals(null)
+      case And(leftFilter, rightFilter) if !parentFilterIsNot =>
+        queryBuilder.and(
+          new SourceFilters(Array(leftFilter)).filtersToDBObject(),
+          new SourceFilters(Array(rightFilter)).filtersToDBObject()
+        )
+      case Or(leftFilter, rightFilter)  if !parentFilterIsNot =>
+        queryBuilder.or(
+          new SourceFilters(Array(leftFilter)).filtersToDBObject(),
+          new SourceFilters(Array(rightFilter)).filtersToDBObject()
+        )
+      case StringStartsWith(attribute, value) if !parentFilterIsNot =>
+        queryBuilder.put(attribute).regex(Pattern.compile("^" + value + ".*$"))
+      case StringEndsWith(attribute, value) if !parentFilterIsNot =>
+        queryBuilder.put(attribute).regex(Pattern.compile("^.*" + value + "$"))
+      case StringContains(attribute, value) if !parentFilterIsNot =>
+        queryBuilder.put(attribute).regex(Pattern.compile(".*" + value + ".*"))
+      case Not(filter) =>
+        new SourceFilters(Array(filter), true).filtersToDBObject()
+    }
+
+    queryBuilder.get
+  }
+
+  /**
+    * Check if the field is "_id" and if the user wants to filter by this field as an ObjectId
+    *
+    * @param attribute Name of the file
+    * @param value Value for the attribute
+    * @return The value in the correct data type
+    */
+  private def checkObjectID(attribute: String, value: Any)(implicit config: Config) : Any = attribute  match {
+    case "_id" if idAsObjectId => new ObjectId(value.toString)
+    case _ => value
+  }
+
+  lazy val idAsObjectId: Boolean =
+    config.getOrElse[String](MongodbConfig.IdAsObjectId, MongodbConfig.DefaultIdAsObjectId).equalsIgnoreCase("true")
+
+}

--- a/spark-mongodb/src/main/scala/com/stratio/datasource/mongodb/query/FilterSection.scala
+++ b/spark-mongodb/src/main/scala/com/stratio/datasource/mongodb/query/FilterSection.scala
@@ -20,7 +20,7 @@ import java.util.regex.Pattern
 import com.mongodb.QueryBuilder
 import com.mongodb.casbah.Imports
 import com.mongodb.casbah.Imports._
-import com.stratio.datasource.mongodb.sources.Near
+import com.stratio.datasource.mongodb.sources.{NearSphere, Near}
 import org.apache.spark.sql.sources._
 import com.stratio.datasource.util.Config
 import com.stratio.datasource.mongodb.config.MongodbConfig
@@ -91,6 +91,10 @@ case class SourceFilters(
         queryBuilder.put(attribute).near(x, y)
       case Near(attribute, x, y, Some(max)) =>
         queryBuilder.put(attribute).near(x, y, max)
+      case NearSphere(attribute, longitude, latitude, None) =>
+        queryBuilder.put(attribute).nearSphere(longitude, latitude)
+      case NearSphere(attribute, longitude, latitude, Some(maxDistance)) =>
+        queryBuilder.put(attribute).nearSphere(longitude, latitude, maxDistance)
       case Not(filter) =>
         SourceFilters(Array(filter), true).filtersToDBObject()
     }

--- a/spark-mongodb/src/main/scala/com/stratio/datasource/mongodb/query/FilterSection.scala
+++ b/spark-mongodb/src/main/scala/com/stratio/datasource/mongodb/query/FilterSection.scala
@@ -20,6 +20,7 @@ import java.util.regex.Pattern
 import com.mongodb.QueryBuilder
 import com.mongodb.casbah.Imports
 import com.mongodb.casbah.Imports._
+import com.stratio.datasource.mongodb.sources.Near
 import org.apache.spark.sql.sources._
 import com.stratio.datasource.util.Config
 import com.stratio.datasource.mongodb.config.MongodbConfig
@@ -86,6 +87,10 @@ class SourceFilters(
         queryBuilder.put(attribute).regex(Pattern.compile("^.*" + value + "$"))
       case StringContains(attribute, value) if !parentFilterIsNot =>
         queryBuilder.put(attribute).regex(Pattern.compile(".*" + value + ".*"))
+      case Near(attribute, x, y, None) =>
+        queryBuilder.put(attribute).near(x, y)
+      case Near(attribute, x, y, Some(max)) =>
+        queryBuilder.put(attribute).near(x, y, max)
       case Not(filter) =>
         new SourceFilters(Array(filter), true).filtersToDBObject()
     }

--- a/spark-mongodb/src/main/scala/com/stratio/datasource/mongodb/query/FilterSection.scala
+++ b/spark-mongodb/src/main/scala/com/stratio/datasource/mongodb/query/FilterSection.scala
@@ -40,11 +40,11 @@ trait FilterSection {
   def filtersToDBObject(): DBObject
 }
 
-object NoFilters extends FilterSection {
+case object NoFilters extends FilterSection {
   override def filtersToDBObject(): Imports.DBObject = QueryBuilder.start.get()
 }
 
-class SourceFilters(
+case class SourceFilters(
                      sFilters: Array[Filter],
                      parentFilterIsNot: Boolean = false
                    )(implicit config: Config) extends FilterSection {
@@ -73,13 +73,13 @@ class SourceFilters(
         queryBuilder.put(attribute).notEquals(null)
       case And(leftFilter, rightFilter) if !parentFilterIsNot =>
         queryBuilder.and(
-          new SourceFilters(Array(leftFilter)).filtersToDBObject(),
-          new SourceFilters(Array(rightFilter)).filtersToDBObject()
+          SourceFilters(Array(leftFilter)).filtersToDBObject(),
+          SourceFilters(Array(rightFilter)).filtersToDBObject()
         )
       case Or(leftFilter, rightFilter)  if !parentFilterIsNot =>
         queryBuilder.or(
-          new SourceFilters(Array(leftFilter)).filtersToDBObject(),
-          new SourceFilters(Array(rightFilter)).filtersToDBObject()
+          SourceFilters(Array(leftFilter)).filtersToDBObject(),
+          SourceFilters(Array(rightFilter)).filtersToDBObject()
         )
       case StringStartsWith(attribute, value) if !parentFilterIsNot =>
         queryBuilder.put(attribute).regex(Pattern.compile("^" + value + ".*$"))
@@ -92,7 +92,7 @@ class SourceFilters(
       case Near(attribute, x, y, Some(max)) =>
         queryBuilder.put(attribute).near(x, y, max)
       case Not(filter) =>
-        new SourceFilters(Array(filter), true).filtersToDBObject()
+        SourceFilters(Array(filter), true).filtersToDBObject()
     }
 
     queryBuilder.get

--- a/spark-mongodb/src/main/scala/com/stratio/datasource/mongodb/rdd/MongodbRDD.scala
+++ b/spark-mongodb/src/main/scala/com/stratio/datasource/mongodb/rdd/MongodbRDD.scala
@@ -20,8 +20,9 @@ import com.stratio.datasource.mongodb.partitioner.{MongodbPartition, MongodbPart
 import com.stratio.datasource.util.Config
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.SQLContext
-import org.apache.spark.sql.sources.Filter
 import org.apache.spark.{Partition, TaskContext}
+
+import com.stratio.datasource.mongodb.query.{NoFilters, FilterSection}
 
 /**
  * @param sc Spark SQLContext
@@ -34,7 +35,7 @@ class MongodbRDD(
   config: Config,
   partitioner: MongodbPartitioner,
   requiredColumns: Array[String] = Array(),
-  filters: Array[Filter] = Array())
+  filters: FilterSection = NoFilters)
   extends RDD[DBObject](sc.sparkContext, deps = Nil) {
 
   override def getPartitions: Array[Partition] =

--- a/spark-mongodb/src/main/scala/com/stratio/datasource/mongodb/rdd/MongodbRDDIterator.scala
+++ b/spark-mongodb/src/main/scala/com/stratio/datasource/mongodb/rdd/MongodbRDDIterator.scala
@@ -16,6 +16,7 @@
 package com.stratio.datasource.mongodb.rdd
 
 import com.mongodb.casbah.Imports._
+import com.stratio.datasource.mongodb.query.FilterSection
 import com.stratio.datasource.mongodb.reader.MongodbReader
 import com.stratio.datasource.util.Config
 import org.apache.spark._
@@ -35,7 +36,7 @@ class MongodbRDDIterator(
   partition: Partition,
   config: Config,
   requiredColumns: Array[String],
-  filters: Array[Filter])
+  filters: FilterSection)
   extends Iterator[DBObject] {
 
   private var closed = false
@@ -75,7 +76,7 @@ class MongodbRDDIterator(
   }
 
   def initReader() = {
-    val reader = new MongodbReader(config,requiredColumns,filters)
+    val reader = new MongodbReader(config, requiredColumns, filters)
     reader.init(partition)
     reader
   }

--- a/spark-mongodb/src/main/scala/com/stratio/datasource/mongodb/sources/customFilters.scala
+++ b/spark-mongodb/src/main/scala/com/stratio/datasource/mongodb/sources/customFilters.scala
@@ -1,0 +1,26 @@
+/**
+ * Copyright (C) 2015 Stratio (http://stratio.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.stratio.datasource.mongodb.sources
+
+import org.apache.spark.sql.sources.Filter
+
+trait GeoFilter extends Filter
+
+case class Near(
+                 attribute: String,
+                 x: Double, y: Double,
+                 maxDistance: Option[Double] = None
+               ) extends GeoFilter

--- a/spark-mongodb/src/main/scala/com/stratio/datasource/mongodb/sources/customFilters.scala
+++ b/spark-mongodb/src/main/scala/com/stratio/datasource/mongodb/sources/customFilters.scala
@@ -17,10 +17,19 @@ package com.stratio.datasource.mongodb.sources
 
 import org.apache.spark.sql.sources.Filter
 
-trait GeoFilter extends Filter
+trait GeoFilter extends Filter {
+  val attribute: String
+  val maxDistance: Option[Double]
+}
 
 case class Near(
                  attribute: String,
                  x: Double, y: Double,
                  maxDistance: Option[Double] = None
                ) extends GeoFilter
+
+case class NearSphere(
+                       attribute: String,
+                       longitude: Double, latitude: Double,
+                       maxDistance: Option[Double] = None
+                     ) extends GeoFilter

--- a/spark-mongodb/src/test/scala/com/stratio/datasource/mongodb/reader/MongodbReaderIT.scala
+++ b/spark-mongodb/src/test/scala/com/stratio/datasource/mongodb/reader/MongodbReaderIT.scala
@@ -26,6 +26,7 @@ import com.stratio.datasource.mongodb._
 import com.stratio.datasource.mongodb.client.MongodbClientFactory
 import com.stratio.datasource.mongodb.config.{MongodbConfig, MongodbConfigBuilder}
 import com.stratio.datasource.mongodb.partitioner.MongodbPartition
+import com.stratio.datasource.mongodb.query.FilterSection
 import com.stratio.datasource.partitioner.PartitionRange
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.mongodb.{TemporaryTestSQLContext, TestSQLContext}
@@ -46,7 +47,7 @@ with BeforeAndAfterAll {
   private val host: String = "localhost"
   private val collection: String = "testCol"
 
-  val testConfig = MongodbConfigBuilder()
+  implicit val testConfig = MongodbConfigBuilder()
     .set(MongodbConfig.Host, List(host + ":" + mongoPort))
     .set(MongodbConfig.Database, db)
     .set(MongodbConfig.Collection, collection)
@@ -57,7 +58,7 @@ with BeforeAndAfterAll {
 
   it should "throw IllegalStateException if next() operation is invoked after closing the Reader" +
     scalaBinaryVersion in {
-    val mongodbReader = new MongodbReader(testConfig,Array(),Array())
+    val mongodbReader = new MongodbReader(testConfig,Array(), FilterSection(Array()))
     mongodbReader.init(
       MongodbPartition(0,
         testConfig[Seq[String]](MongodbConfig.Host),
@@ -73,7 +74,7 @@ with BeforeAndAfterAll {
   it should "not advance the cursor position when calling hasNext() operation" + scalaBinaryVersion in {
     withEmbedMongoFixture(complexFieldAndType1) { mongodbProc =>
 
-      val mongodbReader = new MongodbReader(testConfig,Array(),Array())
+      val mongodbReader = new MongodbReader(testConfig,Array(),FilterSection(Array()))
       mongodbReader.init(
         MongodbPartition(0,
           testConfig[Seq[String]](MongodbConfig.Host),
@@ -87,7 +88,7 @@ with BeforeAndAfterAll {
   it should "advance the cursor position when calling next() operation" + scalaBinaryVersion in {
     withEmbedMongoFixture(complexFieldAndType1) { mongodbProc =>
 
-      val mongodbReader = new MongodbReader(testConfig,Array(),Array())
+      val mongodbReader = new MongodbReader(testConfig,Array(),FilterSection(Array()))
       mongodbReader.init(
         MongodbPartition(0,
           testConfig[Seq[String]](MongodbConfig.Host),
@@ -120,7 +121,7 @@ with BeforeAndAfterAll {
     withEmbedMongoFixture(primitiveFieldAndType) { mongodbProc =>
       //Test data preparation
       val requiredColumns = Array("_id","string", "integer")
-      val filters = Array[Filter](EqualTo("boolean", true))
+      val filters = FilterSection(Array[Filter](EqualTo("boolean", true)))
       val mongodbReader =
         new MongodbReader(testConfig, requiredColumns, filters)
 
@@ -156,7 +157,7 @@ with BeforeAndAfterAll {
 
       //Test data preparation
       val requiredColumns = Array("_id","string", "integer")
-      val filters = Array[Filter](EqualTo("boolean", true))
+      val filters = FilterSection(Array[Filter](EqualTo("boolean", true)))
       val mongodbReader =
         new MongodbReader(testConfig, requiredColumns, filters)
 


### PR DESCRIPTION
This PR enables It also enable Geo filters and increases the level of abstraction used to represent the filter section at classes such as `MongodbRdd` and `MongodbReader`. Instead of just passing an `Array[Filter]`, not a `FilterSection` instance is expected. This class might have many implementations which should be able to generate a `DBObject` representing the filter section through the `filtersToDBObject` method. 

At this moment, three implementations of `FilterSection` are available:
- `SourceFilters` which is the classic `Array[Filter]` filter section description
- `NoFilters` which is equivalent to an empty `SourceFilters` instance.
- `RawFilter`, allowing to provide a filter as you would if you were using the bare mongodb driver.

