### PR TITLE
fix reading properties without changing old configuration

### DIFF
--- a/spark-mongodb/src/main/scala/com/stratio/datasource/mongodb/partitioner/MongodbPartitioner.scala
+++ b/spark-mongodb/src/main/scala/com/stratio/datasource/mongodb/partitioner/MongodbPartitioner.scala
@@ -45,7 +45,10 @@ class MongodbPartitioner(config: Config) extends Partitioner[MongodbPartition] {
   @transient private val ssloptions: Option[MongodbSSLOptions] =
     config.get[MongodbSSLOptions](MongodbConfig.SSLOptions)
 
-  private val clientOptions = config.properties //config.properties.filterKeys(_.contains(MongodbConfig.ListMongoClientOptions)) // TODO review this Map. Can't filter keys
+  private val clientOptions = {
+    val lowerCaseOptions = MongodbConfig.ListMongoClientOptions.map(_.toLowerCase).toSet
+    config.properties.filter { case (k, _) => lowerCaseOptions contains k }
+  }
 
   private val databaseName: String = config(MongodbConfig.Database)
 

--- a/spark-mongodb/src/main/scala/com/stratio/datasource/util/Config.scala
+++ b/spark-mongodb/src/main/scala/com/stratio/datasource/util/Config.scala
@@ -62,7 +62,7 @@ abstract class ConfigBuilder[Builder<:ConfigBuilder[Builder] ](
    */
   def build(): Config = new Config {
 
-    val properties = builder.properties
+    val properties = builder.properties.map { case (k, v) => k.toLowerCase -> v }
 
     require(
       requiredProperties.forall(properties.isDefinedAt),
@@ -109,10 +109,8 @@ trait Config extends Serializable {
    *   @return  the value associated with `key` if it exists,
    *            otherwise the result of the `default` computation.
    */
-  def getOrElse[T](key: Property, default: => T): T = properties.get(key) match {
-    case Some(v) => v.asInstanceOf[T]
-    case None => default
-  }
+  def getOrElse[T](key: Property, default: => T): T =
+    properties.get(key.toLowerCase) collect { case v: T => v } getOrElse default
 
   /**
    * Gets specified property from current configuration object
@@ -121,7 +119,7 @@ trait Config extends Serializable {
    * @return An optional value of expected type
    */
   def get[T: ClassTag](property: Property): Option[T] =
-    properties.get(property).map(_.asInstanceOf[T])
+    properties.get(property.toLowerCase).map(_.asInstanceOf[T])
 
   /**
    * Gets specified property from current configuration object.


### PR DESCRIPTION
it fixes #111, and unlike #112, it doesn't require to change old configuration, it's implemented inspired by the org.apache.spark.sql.execution.datasources.CaseInsensitiveMap in SPARK-SQL.