### PR TITLE
Take empty arrays type as arrays of Strings #124

### DIFF
--- a/spark-mongodb/src/test/scala/com/stratio/datasource/mongodb/TestBsonData.scala
+++ b/spark-mongodb/src/test/scala/com/stratio/datasource/mongodb/TestBsonData.scala
@@ -96,6 +96,7 @@ trait TestBsonData {
           "arrayOfDouble":[1.2, 1.7976931348623157E308, 4.9E-324, 2.2250738585072014E-308],
           "arrayOfBoolean":[true, false, true],
           "arrayOfNull":[null, null, null, null],
+          "arrayEmpty":[],
           "arrayOfStruct":[{"field1": true, "field2": "str1"}, {"field1": false}, {"field3": null}],
           "arrayOfArray1":[[1, 2, 3], ["str1", "str2"]],
           "arrayOfArray2":[[1, 2, 3], [1.1, 2.1, 3.1]]

--- a/spark-mongodb/src/test/scala/com/stratio/datasource/mongodb/schema/MongodbSchemaIT.scala
+++ b/spark-mongodb/src/test/scala/com/stratio/datasource/mongodb/schema/MongodbSchemaIT.scala
@@ -24,8 +24,7 @@ import com.stratio.datasource.mongodb.partitioner.MongodbPartitioner
 import com.stratio.datasource.mongodb.rdd.MongodbRDD
 import com.stratio.datasource.mongodb._
 import org.apache.spark.sql.mongodb.{TemporaryTestSQLContext, TestSQLContext}
-
-import org.apache.spark.sql.types.TimestampType
+import org.apache.spark.sql.types.{ArrayType, StringType, StructField, TimestampType}
 import org.junit.runner.RunWith
 import org.scalatest._
 import org.scalatest.junit.JUnitRunner
@@ -70,7 +69,12 @@ with MongodbTestConstants {
     withEmbedMongoFixture(complexFieldAndType1) { mongodProc =>
       val schema = MongodbSchema(mongodbRDD, 1.0).schema()
 
-      schema.fields should have size 12
+      schema.fields should have size 13
+
+      schema.fields filter {
+        case StructField(name, ArrayType(StringType, _), _, _) => Set("arrayOfNull", "arrayEmpty") contains name
+        case _ => false
+      } should have size 2
 
       schema.printTreeString()
     }


### PR DESCRIPTION
After this PR has been merged, empty, or with all is element being null, arrays will be classified within sparkSQL types taxonomy as ArrayType(StringType, )