### PR TITLE
Ensure connections are being closed

### DIFF
--- a/spark-mongodb/src/main/scala/com/stratio/datasource/mongodb/MongodbDataFrame.scala
+++ b/spark-mongodb/src/main/scala/com/stratio/datasource/mongodb/MongodbDataFrame.scala
@@ -17,7 +17,7 @@
 package com.stratio.datasource.mongodb
 
 import com.stratio.datasource.mongodb.schema.MongodbRowConverter
-import com.stratio.datasource.mongodb.writer.{MongodbSimpleWriter, MongodbBatchWriter}
+import com.stratio.datasource.mongodb.writer.{MongodbBatchWriter, MongodbSimpleWriter}
 import com.stratio.datasource.util.Config
 import org.apache.spark.sql.DataFrame
 
@@ -39,10 +39,13 @@ class MongodbDataFrame(dataFrame: DataFrame) extends Serializable {
       val writer =
         if (batch) new MongodbBatchWriter(config)
         else new MongodbSimpleWriter(config)
-      writer.saveWithPk(it.map(row =>
-        MongodbRowConverter.rowAsDBObject(row, schema)))
-      writer.freeConnection()
+
+      writer.saveWithPk(
+        it.map(row => MongodbRowConverter.rowAsDBObject(row, schema)))
+
     })
   }
+
+
 
 }

--- a/spark-mongodb/src/main/scala/com/stratio/datasource/mongodb/client/MongodbClientActor.scala
+++ b/spark-mongodb/src/main/scala/com/stratio/datasource/mongodb/client/MongodbClientActor.scala
@@ -31,11 +31,12 @@ import scala.annotation.tailrec
 import scala.util.Try
 
 
+// TODO Refactor - "The MongoClient class is designed to be thread safe and shared among threads"
 class MongodbClientActor extends Actor {
 
   private val KeySeparator = "-"
 
-  private val CloseSleepTime = 1000
+  private val CloseSleepTime = 100
 
   private val mongoClient: scala.collection.mutable.Map[String, MongodbConnection] =
     scala.collection.mutable.Map.empty[String, MongodbConnection]

--- a/spark-mongodb/src/main/scala/com/stratio/datasource/mongodb/client/MongodbClientFactory.scala
+++ b/spark-mongodb/src/main/scala/com/stratio/datasource/mongodb/client/MongodbClientFactory.scala
@@ -25,7 +25,7 @@ import com.mongodb.ServerAddress
 import com.mongodb.casbah.Imports._
 import com.mongodb.casbah.MongoClient
 import com.stratio.datasource.mongodb.client.MongodbClientActor._
-import com.stratio.datasource.mongodb.config.MongodbSSLOptions
+import com.stratio.datasource.mongodb.config.{MongodbConfig, MongodbSSLOptions}
 import com.typesafe.config.ConfigFactory
 
 import scala.concurrent.Await
@@ -35,6 +35,7 @@ import scala.concurrent.duration._
 /**
  * Different client configurations to Mongodb database
  */
+// TODO Refactor - MongodbClientFactory should be used internally and should not delegate to other when closing/freeing connections
 object MongodbClientFactory {
 
   type Client = MongoClient
@@ -46,7 +47,7 @@ object MongodbClientFactory {
    */
   private val actorSystem = ActorSystem("mongodbClientFactory", ConfigFactory.load(ConfigFactory.parseString("akka.daemonic=on")))
   private val scheduler = actorSystem.scheduler
-  private val SecondsToCheckConnections = 60
+  private val SecondsToCheckConnections = MongodbConfig.DefaultConnectionsTime
   private val mongoConnectionsActor = actorSystem.actorOf(Props(new MongodbClientActor), "mongoConnectionActor")
 
   private implicit val executor = actorSystem.dispatcher
@@ -63,7 +64,7 @@ object MongodbClientFactory {
    * @param host Ip or Dns to connect
    * @return Client connection with identifier
    */
-  def getClient(host: String): ClientResponse = {
+  private[mongodb] def getClient(host: String): ClientResponse = {
     val futureResult = mongoConnectionsActor ? GetClient(host)
     Await.result(futureResult, timeout.duration) match {
       case ClientResponse(key, clientConnection) => ClientResponse(key, clientConnection)
@@ -79,7 +80,7 @@ object MongodbClientFactory {
    * @param password Password for credentials
    * @return Client connection with identifier
    */
-  def getClient(host: String, port: Int, user: String, database: String, password: String): ClientResponse = {
+  private[mongodb] def getClient(host: String, port: Int, user: String, database: String, password: String): ClientResponse = {
     val futureResult = mongoConnectionsActor ? GetClientWithUser(host, port, user, database, password)
     Await.result(futureResult, timeout.duration) match {
       case ClientResponse(key, clientConnection) => ClientResponse(key, clientConnection)
@@ -94,7 +95,7 @@ object MongodbClientFactory {
    * @param clientOptions All options for the client connections
    * @return Client connection with identifier
    */
-  def getClient(hostPort: List[ServerAddress],
+  private[mongodb] def getClient(hostPort: List[ServerAddress],
                 credentials: List[MongoCredential] = List(),
                 optionSSLOptions: Option[MongodbSSLOptions] = None,
                 clientOptions: Map[String, Any] = Map()): ClientResponse = {
@@ -110,7 +111,7 @@ object MongodbClientFactory {
    * Close all client connections on the concurrent map
    * @param gracefully Close the connections if is free
    */
-  def closeAll(gracefully: Boolean = true, attempts: Int = CloseAttempts): Unit = {
+  private[mongodb] def closeAll(gracefully: Boolean = true, attempts: Int = CloseAttempts): Unit = {
     mongoConnectionsActor ! CloseAll(gracefully, attempts)
   }
 
@@ -119,7 +120,7 @@ object MongodbClientFactory {
    * @param client client value for connect to MongoDb
    * @param gracefully Close the connection if is free
    */
-  def closeByClient(client: Client, gracefully: Boolean = true): Unit = {
+  private[mongodb] def closeByClient(client: Client, gracefully: Boolean = true): Unit = {
     mongoConnectionsActor ! CloseByClient(client, gracefully)
   }
 
@@ -128,7 +129,7 @@ object MongodbClientFactory {
    * @param clientKey key pre calculated with the connection options
    * @param gracefully Close the connection if is free
    */
-  def closeByKey(clientKey: String, gracefully: Boolean = true): Unit = {
+  private[mongodb] def closeByKey(clientKey: String, gracefully: Boolean = true): Unit = {
     mongoConnectionsActor ! CloseByKey(clientKey, gracefully)
   }
 
@@ -136,7 +137,7 @@ object MongodbClientFactory {
    * Set Free the connection that have the same client as the client param
    * @param client client value for connect to MongoDb
    */
-  def setFreeConnectionByClient(client: Client, extendedTime: Option[Long] = None): Unit = {
+  private[mongodb] def setFreeConnectionByClient(client: Client, extendedTime: Option[Long] = None): Unit = {
     mongoConnectionsActor ! SetFreeConnectionsByClient(client, extendedTime)
   }
 
@@ -144,11 +145,11 @@ object MongodbClientFactory {
    * Set Free the connection that have the same key as the clientKey param
    * @param clientKey key pre calculated with the connection options
    */
-  def setFreeConnectionByKey(clientKey: String, extendedTime: Option[Long] = None): Unit = {
+  private[mongodb] def setFreeConnectionByKey(clientKey: String, extendedTime: Option[Long] = None): Unit = {
     mongoConnectionsActor ! SetFreeConnectionByKey(clientKey, extendedTime)
   }
 
-  def getClientPoolSize: Int = {
+  private[client] def getClientPoolSize: Int = {
     val futureResult = mongoConnectionsActor ? GetSize
     Await.result(futureResult, timeout.duration) match {
       case size: Int => size

--- a/spark-mongodb/src/main/scala/com/stratio/datasource/mongodb/config/MongodbConfig.scala
+++ b/spark-mongodb/src/main/scala/com/stratio/datasource/mongodb/config/MongodbConfig.scala
@@ -84,7 +84,7 @@ object MongodbConfig {
   val DefaultSamplingRatio = 1.0
   val DefaultSplitSize = 10
   val DefaultSplitKey = "_id"
-  val DefaultConnectionsTime = 120000L
+  val DefaultConnectionsTime = 10000L
   val DefaultCursorBatchSize = 101
   val DefaultBulkBatchSize = 1000
   val DefaultIdAsObjectId = "true"

--- a/spark-mongodb/src/main/scala/com/stratio/datasource/mongodb/config/MongodbConfigReader.scala
+++ b/spark-mongodb/src/main/scala/com/stratio/datasource/mongodb/config/MongodbConfigReader.scala
@@ -1,0 +1,32 @@
+package com.stratio.datasource.mongodb.config
+
+import com.mongodb.casbah.Imports._
+import com.mongodb.{MongoCredential, ServerAddress}
+import com.stratio.datasource.mongodb.config.MongodbConfig._
+import com.stratio.datasource.util.Config
+
+object MongodbConfigReader {
+
+  implicit class MongodbConfigFunctions(config: Config) {
+    @transient protected[mongodb] val hosts : List[ServerAddress] =
+      config[List[String]](MongodbConfig.Host)
+        .map(add => new ServerAddress(add))
+
+    @transient protected[mongodb] val credentials: List[MongoCredential] =
+      config.getOrElse[List[MongodbCredentials]](MongodbConfig.Credentials, MongodbConfig.DefaultCredentials).map{
+        case MongodbCredentials(user,database,password) =>
+          MongoCredential.createCredential(user,database,password)
+      }
+
+    @transient protected[mongodb] val sslOptions: Option[MongodbSSLOptions] =
+      config.get[MongodbSSLOptions](MongodbConfig.SSLOptions)
+
+    @transient protected[mongodb] val writeConcern: WriteConcern = config.get[String](MongodbConfig.WriteConcern) match {
+      case Some(wConcern) => parseWriteConcern(wConcern)
+      case None => DefaultWriteConcern
+    }
+
+    protected[mongodb] val clientOptions = config.properties.filterKeys(_.contains(MongodbConfig.ListMongoClientOptions))
+  }
+
+}

--- a/spark-mongodb/src/main/scala/com/stratio/datasource/mongodb/config/MongodbConfigReader.scala
+++ b/spark-mongodb/src/main/scala/com/stratio/datasource/mongodb/config/MongodbConfigReader.scala
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2015 Stratio (http://stratio.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.stratio.datasource.mongodb.config
 
 import com.mongodb.casbah.Imports._

--- a/spark-mongodb/src/main/scala/com/stratio/datasource/mongodb/reader/MongodbReader.scala
+++ b/spark-mongodb/src/main/scala/com/stratio/datasource/mongodb/reader/MongodbReader.scala
@@ -15,15 +15,12 @@
  */
 package com.stratio.datasource.mongodb.reader
 
-import java.util.regex.Pattern
-
-import com.mongodb.QueryBuilder
 import com.mongodb.casbah.Imports._
 import com.mongodb.casbah.MongoCursorBase
-import com.stratio.datasource.mongodb.query.FilterSection
 import com.stratio.datasource.mongodb.client.MongodbClientFactory
-import com.stratio.datasource.mongodb.config.{MongodbSSLOptions, MongodbCredentials, MongodbConfig}
+import com.stratio.datasource.mongodb.config.{MongodbConfig, MongodbCredentials, MongodbSSLOptions}
 import com.stratio.datasource.mongodb.partitioner.MongodbPartition
+import com.stratio.datasource.mongodb.query.FilterSection
 import com.stratio.datasource.util.Config
 import org.apache.spark.Partition
 
@@ -58,10 +55,8 @@ class MongodbReader(config: Config,
 
     mongoClient.fold(ifEmpty = ()) { client =>
       mongoClientKey.fold({
-        MongodbClientFactory.setFreeConnectionByClient(client, connectionsTime)
         MongodbClientFactory.closeByClient(client)
       }) {key =>
-        MongodbClientFactory.setFreeConnectionByKey(key, connectionsTime)
         MongodbClientFactory.closeByKey(key)
       }
 

--- a/spark-mongodb/src/main/scala/com/stratio/datasource/mongodb/util/usingMongoClient.scala
+++ b/spark-mongodb/src/main/scala/com/stratio/datasource/mongodb/util/usingMongoClient.scala
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2015 Stratio (http://stratio.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.stratio.datasource.mongodb.util
 
 import com.mongodb.casbah.MongoClient

--- a/spark-mongodb/src/main/scala/com/stratio/datasource/mongodb/util/usingMongoClient.scala
+++ b/spark-mongodb/src/main/scala/com/stratio/datasource/mongodb/util/usingMongoClient.scala
@@ -1,0 +1,17 @@
+package com.stratio.datasource.mongodb.util
+
+import com.mongodb.casbah.MongoClient
+import com.stratio.datasource.mongodb.client.MongodbClientFactory
+
+import scala.util.Try
+
+  object usingMongoClient {
+
+    def apply[A](mongoClient: MongoClient)(code: MongoClient => A): A =
+      try {
+        code(mongoClient)
+      } finally {
+        Try(MongodbClientFactory.closeByClient(mongoClient))
+      }
+  }
+

--- a/spark-mongodb/src/main/scala/com/stratio/datasource/mongodb/writer/MongodbBatchWriter.scala
+++ b/spark-mongodb/src/main/scala/com/stratio/datasource/mongodb/writer/MongodbBatchWriter.scala
@@ -25,7 +25,7 @@ import com.stratio.datasource.util.Config
  *
  * @param config Configuration parameters (host,database,collection,...)
  */
-class MongodbBatchWriter(config: Config) extends MongodbWriter(config) {
+private[mongodb] class MongodbBatchWriter(config: Config) extends MongodbWriter(config) {
 
   private val IdKey = "_id"
 
@@ -33,9 +33,9 @@ class MongodbBatchWriter(config: Config) extends MongodbWriter(config) {
 
   private val pkConfig: Option[Array[String]] = config.get[Array[String]](MongodbConfig.UpdateFields)
 
-  override def save(it: Iterator[DBObject]): Unit = {
+  override def save(it: Iterator[DBObject], mongoClient: MongoClient): Unit = {
     it.grouped(bulkBatchSize).foreach { group =>
-      val bulkOperation = dbCollection.initializeUnorderedBulkOperation
+      val bulkOperation = dbCollection(mongoClient).initializeUnorderedBulkOperation
       group.foreach { element =>
         val query = getUpdateQuery(element)
         if (query.isEmpty) bulkOperation.insert(element)

--- a/spark-mongodb/src/main/scala/com/stratio/datasource/mongodb/writer/MongodbSimpleWriter.scala
+++ b/spark-mongodb/src/main/scala/com/stratio/datasource/mongodb/writer/MongodbSimpleWriter.scala
@@ -16,7 +16,6 @@
 package com.stratio.datasource.mongodb.writer
 
 import com.mongodb.casbah.Imports._
-import com.stratio.datasource.mongodb.config.MongodbConfig
 import com.stratio.datasource.util.Config
 
 /**
@@ -24,9 +23,9 @@ import com.stratio.datasource.util.Config
  *
  * @param config Configuration parameters (host,database,collection,...)
  */
-class MongodbSimpleWriter(config: Config) extends MongodbWriter(config) {
+private[mongodb] class MongodbSimpleWriter(config: Config) extends MongodbWriter(config) {
 
-  override def save(it: Iterator[DBObject]): Unit =
-    it.foreach(dbo => dbCollection.save(dbo, writeConcern))
+  override def save(it: Iterator[DBObject], mongoClient: MongoClient): Unit =
+    it.foreach(dbo => dbCollection(mongoClient).save(dbo, writeConcern))
 
 }


### PR DESCRIPTION
It is the first step to solve [the connections issue](https://github.com/Stratio/Spark-MongoDB/issues/131). As @wuciawe pointed out, there were several leaks.

Once the issue is solved, We'll clean up the MongodbClientFactory by removing the connection reuse because it's not working properly. Therefore, a new MongoClient will be created per partition.

Meanwhile, we will be working on the connection handler refactor, working with a single MongoClient instance per executor/config. It will be available soon (for 0.12.X)