### PR TITLE
Upgrade casbah to 3.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.12.0 (? 2016)
+
+* Upgrade casbah to 3.1.1 (compatible with MongoDB 3.2)
+
 ## 0.11.1 (? 2016)
 
 * Max and Min splitVector bounds for not sharded collections (see doc)

--- a/pom.xml
+++ b/pom.xml
@@ -42,8 +42,12 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <sonar.projectBaseDir>spark-mongodb</sonar.projectBaseDir>
+        <scala.test.version>2.2.5</scala.test.version>
+        <scala.mock.version>3.2.1</scala.mock.version>
+        <spark.version>1.6.1</spark.version>
+        <casbah.version>3.1.1</casbah.version>
     </properties>
-
     <developers>
         <developer>
             <id>rmorandeira</id>

--- a/spark-mongodb/src/main/scala/com/stratio/datasource/mongodb/config/MongodbConfig.scala
+++ b/spark-mongodb/src/main/scala/com/stratio/datasource/mongodb/config/MongodbConfig.scala
@@ -159,13 +159,12 @@ object MongodbConfig {
   // TODO Review when refactoring config
   def parseWriteConcern(writeConcern: String): WriteConcern = {
     writeConcern.toUpperCase match {
-      case "SAFE" | "ACKNOWLEDGED" => com.mongodb.WriteConcern.SAFE
-      case "NORMAL" | "UNACKNOWLEDGED" => com.mongodb.WriteConcern.NORMAL
-      case "REPLICAS_SAFE" | "REPLICA_ACKNOWLEDGED" => com.mongodb.WriteConcern.REPLICAS_SAFE
+      case "SAFE" | "ACKNOWLEDGED" => com.mongodb.WriteConcern.ACKNOWLEDGED
+      case "NORMAL" | "UNACKNOWLEDGED" => com.mongodb.WriteConcern.UNACKNOWLEDGED
+      case "REPLICAS_SAFE" | "REPLICA_ACKNOWLEDGED" => com.mongodb.WriteConcern.W2
       case "FSYNC_SAFE" | "FSYNCED" => com.mongodb.WriteConcern.FSYNC_SAFE
       case "MAJORITY" => com.mongodb.WriteConcern.MAJORITY
-      case "JOURNAL_SAFE" | "JOURNALED" => com.mongodb.WriteConcern.JOURNAL_SAFE
-      case "NONE" | "ERRORS_IGNORED" => com.mongodb.WriteConcern.NONE
+      case "JOURNAL_SAFE" | "JOURNALED" => com.mongodb.WriteConcern.JOURNALED
       case _ => DefaultWriteConcern
     }
   }

--- a/spark-mongodb_2.10/pom.xml
+++ b/spark-mongodb_2.10/pom.xml
@@ -30,11 +30,6 @@
     <properties>
         <scala.version>2.10.4</scala.version>
         <scala.binary.version>2.10</scala.binary.version>
-        <sonar.projectBaseDir>spark-mongodb</sonar.projectBaseDir>
-        <scala.test.version>2.2.5</scala.test.version>
-        <scala.mock.version>3.2.1</scala.mock.version>
-        <spark.version>1.6.1</spark.version>
-        <casbah.version>2.8.0</casbah.version>
     </properties>
     <dependencies>
         <dependency>

--- a/spark-mongodb_2.11/pom.xml
+++ b/spark-mongodb_2.11/pom.xml
@@ -30,11 +30,6 @@
     <properties>
         <scala.version>2.11.6</scala.version>
         <scala.binary.version>2.11</scala.binary.version>
-        <sonar.projectBaseDir>spark-mongodb</sonar.projectBaseDir>
-        <scala.test.version>2.2.5</scala.test.version>
-        <scala.mock.version>3.2.1</scala.mock.version>
-        <spark.version>1.5.2</spark.version>
-        <casbah.version>2.8.0</casbah.version>
     </properties>
     <dependencies>
         <dependency>


### PR DESCRIPTION
That's necessary to make spark-mongodb compatible with MongoDB 3.2
