### PR TITLE
Enable Kerberos based authentication for mongo

### DIFF
--- a/spark-mongodb/src/main/scala/com/stratio/datasource/mongodb/config/DBCredentials.scala
+++ b/spark-mongodb/src/main/scala/com/stratio/datasource/mongodb/config/DBCredentials.scala
@@ -1,0 +1,8 @@
+package com.stratio.datasource.mongodb.config
+
+/**
+  * Created by singhulariti on 7/26/16.
+  */
+trait DBCredentials {
+
+}

--- a/spark-mongodb/src/main/scala/com/stratio/datasource/mongodb/config/DBCredentials.scala
+++ b/spark-mongodb/src/main/scala/com/stratio/datasource/mongodb/config/DBCredentials.scala
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2015 Stratio (http://stratio.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.stratio.datasource.mongodb.config
 
 /**

--- a/spark-mongodb/src/main/scala/com/stratio/datasource/mongodb/config/MongodbConfig.scala
+++ b/spark-mongodb/src/main/scala/com/stratio/datasource/mongodb/config/MongodbConfig.scala
@@ -128,9 +128,9 @@ object MongodbConfig {
       case (properties,GSSAPICredentials) =>
         parameters.get(GSSAPICredentials).map{ gssapiCredentialInput =>
           val gssApiCredentials = gssapiCredentialInput.split(",").map(_.split(",")).toList
-            .map(credential => MongodbGSSAPICredentials(credential(0), credential(1),
-              credential(2).asInstanceOf[Map[String, String]],
-              credential(3).asInstanceOf[Map[String, Any]]))
+            .map(credential => MongodbGSSAPICredentials(credential(0),
+              credential(1).asInstanceOf[Map[String, String]],
+              credential(2).asInstanceOf[Map[String, Any]]))
           properties + (GSSAPICredentials -> gssApiCredentials)
         } getOrElse properties
 

--- a/spark-mongodb/src/main/scala/com/stratio/datasource/mongodb/config/MongodbConfigReader.scala
+++ b/spark-mongodb/src/main/scala/com/stratio/datasource/mongodb/config/MongodbConfigReader.scala
@@ -28,9 +28,20 @@ object MongodbConfigReader {
         .map(add => new ServerAddress(add))
 
     @transient protected[mongodb] val credentials: List[MongoCredential] =
-      config.getOrElse[List[MongodbCredentials]](MongodbConfig.Credentials, MongodbConfig.DefaultCredentials).map{
+      config.getOrElse[List[DBCredentials]](MongodbConfig.Credentials,
+        config.getOrElse[List[DBCredentials]](MongodbConfig.GSSAPICredentials, MongodbConfig.DefaultCredentials)).map{
+
         case MongodbCredentials(user,database,password) =>
           MongoCredential.createCredential(user,database,password)
+
+        case MongodbGSSAPICredentials(user, database, envProperties, mechanismProperties) =>
+
+          envProperties.keys.foreach(k => System.setProperty(k, envProperties(k)))
+
+          val credential = MongoCredential.createGSSAPICredential(user)
+
+          mechanismProperties.keys.foreach(k => credential.withMechanismProperty(k, mechanismProperties(k)))
+          credential
       }
 
     @transient protected[mongodb] val sslOptions: Option[MongodbSSLOptions] =

--- a/spark-mongodb/src/main/scala/com/stratio/datasource/mongodb/config/MongodbConfigReader.scala
+++ b/spark-mongodb/src/main/scala/com/stratio/datasource/mongodb/config/MongodbConfigReader.scala
@@ -34,7 +34,7 @@ object MongodbConfigReader {
         case MongodbCredentials(user,database,password) =>
           MongoCredential.createCredential(user,database,password)
 
-        case MongodbGSSAPICredentials(user, database, envProperties, mechanismProperties) =>
+        case MongodbGSSAPICredentials(user, envProperties, mechanismProperties) =>
 
           envProperties.keys.foreach(k => System.setProperty(k, envProperties(k)))
 

--- a/spark-mongodb/src/main/scala/com/stratio/datasource/mongodb/config/MongodbGSSAPICredentials.scala
+++ b/spark-mongodb/src/main/scala/com/stratio/datasource/mongodb/config/MongodbGSSAPICredentials.scala
@@ -17,6 +17,5 @@ package com.stratio.datasource.mongodb.config
 
 case class MongodbGSSAPICredentials(
   user: String,
-  database: String,
   envProperties: Map[String, String],
   mechanismProperties: Map[String, Any]) extends DBCredentials

--- a/spark-mongodb/src/main/scala/com/stratio/datasource/mongodb/config/MongodbGSSAPICredentials.scala
+++ b/spark-mongodb/src/main/scala/com/stratio/datasource/mongodb/config/MongodbGSSAPICredentials.scala
@@ -15,7 +15,8 @@
  */
 package com.stratio.datasource.mongodb.config
 
-case class MongodbCredentials(
+case class MongodbGSSAPICredentials(
   user: String,
   database: String,
-  password: Array[Char]) extends DBCredentials
+  envProperties: Map[String, String],
+  mechanismProperties: Map[String, Any]) extends DBCredentials


### PR DESCRIPTION
This should allow authenticating to Mongo via GSSAPI settings. It expects the username, any environment variable you need to set as a map. You can also pass any additional mechanism settings you need on the credential as a map. 

Example:

GSSAPICredentials -> List("principal", Map(("java.security.auth.login.config", "/path/to/file/on_executor"), Map(("REALM", "xyz")))